### PR TITLE
chore(docs): improve issues template for documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -4,11 +4,19 @@ about: Documentation in general
 labels: documentation
 ---
 
-## What it covers?
+## What needs to be documented?
 
-<!-- Brief summary of the post topic -->
+<!-- What should be added, clarified, corrected, or removed? -->
+
+## Where
+
+<!-- Which file, page, or section should change? -->
+
+## Why
+
+<!-- What confusion, missing detail, or outdated information does this fix? -->
 
 ## Status
 
-- [ ] Draft in progress
-- [ ] Ready to publish
+- [ ] Documentation is clear and accurate
+- [ ] Examples, commands, and links were checked (if applicable)


### PR DESCRIPTION
## What changed

GitHub Issues Template found in `.github/ISSUE_TEMPLATE/documentation.md`.

## Related issue

Closes #24

## How to test

No need.

- [x] Docs only
- [x] `npm run build` passes
