### PR TITLE
chore(workflows): disable deploy on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [main]
+  # push:
+  #   branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What changed

Disable deploys on push/merge to `main`.

## Related issue

Closes #26

## How to test

No tests required.

- [x] Deploy on demand manually
- [x] `npm run build` passes
