### PR TITLE
feat(seo): extract first post image for og:image

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -58,12 +58,35 @@ interface Props {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
+
+const postImages = import.meta.glob<{ default: ImageMetadata }>(
+  '/src/content/posts/**/images/*.{png,jpg,jpeg,gif,webp,avif}',
+  { eager: true },
+);
+
+function getFirstBodyImage(body: string | undefined, entryId: string): string | undefined {
+  const match = body?.match(/!\[.*?\]\(\.\/images\/([^)]+)\)/);
+  if (!match) return undefined;
+
+  const entryDir = entryId.replace(/\/[^/]+$/, '');
+  const key = `/src/content/posts/${entryDir}/images/${match[1]}`;
+  return postImages[key]?.default.src;
+}
+
+const site = Astro.site ?? new URL('https://www.otaviomiranda.com.br');
+const resolvedImage = entry.data.image ?? getFirstBodyImage(entry.body, entry.id);
+const ogImage = resolvedImage?.startsWith('http')
+  ? resolvedImage
+  : resolvedImage
+    ? new URL(resolvedImage, site).toString()
+    : undefined;
 ---
 
 <BaseLayout
   title={entry.data.title + ' - Otávio Miranda'}
   description={entry.data.description}
-  image={entry.data.image}
+  image={ogImage}
+  ogType='article'
 >
   <Header />
 


### PR DESCRIPTION
## Summary
- Automatically extracts the first `![...](./images/...)` from the markdown body to use as `og:image` and `twitter:image`
- Priority: frontmatter `image` > first body image > BaseLayout default fallback
- Sets `og:type` to `article` on post pages (was `website`)
- Zero runtime impact — all resolved at build time via `import.meta.glob`

## Test plan
- [x] Build passes
- [x] Post with body images gets correct absolute OG image URL
- [x] Post without images falls back to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)