### PR TITLE
chore(coupon): update June 2026 coupon

### DIFF
--- a/src/config/coupon.ts
+++ b/src/config/coupon.ts
@@ -20,6 +20,6 @@ export interface CouponConfig {
 }
 
 export const HOME_COUPON: CouponConfig = {
-  code: 'MAIO_2026',
-  expiresAtLabel: 'Expira em 22/05/2026 às 11h11',
+  code: 'JUN2026',
+  expiresAtLabel: 'Expira em 08/06/2026 às 21h14',
 };


### PR DESCRIPTION
## What changed
Updated the home page coupon config with the June 2026 Udemy coupon values.

## Related issue
closes #143

## How to test

- [x] Home coupon shows `JUN2026`
- [x] Home coupon expiration label shows `Expira em 08/06/2026 às 21h14`
- [x] `npm run build` passes