### PR TITLE
fix(ui): restore pill control padding

### DIFF
--- a/src/components/ColorfulBorder.astro
+++ b/src/components/ColorfulBorder.astro
@@ -102,7 +102,7 @@ const { class: className } = Astro.props;
       justify-content: center;
       align-items: center;
 
-      > * {
+      > :global(*) {
         padding: clamp(var(--space-200), 3vw, var(--space-300))
           clamp(var(--space-400), 3vw, var(--space-900));
       }


### PR DESCRIPTION
## What changed
Restore padding on shared `ColorfulBorder` slotted controls by changing the direct child selector to `> :global(*)`.

## Why
After the Astro 7 upgrade, the scoped nested selector inside `ColorfulBorder` no longer reached slotted children such as the `PillLink` anchors in the home hero. The visual result was the pill border sitting directly against the text.

This keeps the wrapper scoped while intentionally allowing the direct slotted control (`a`, `button`, `input`) to receive the shared padding.

## Related issue
closes #177

## How to test
- [x] `npx prettier --check --config .prettierrc.json src/components/ColorfulBorder.astro` passes
- [x] `npm run build` passes
- [x] generated CSS now emits the slotted child padding as `.container[data-astro-cid-edqzpt2h] ... .el { & > * { padding: ... } }`, which reaches the slotted controls