### PR TITLE
fix(rss): limit feed to recent posts

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -47,7 +47,7 @@ export async function GET(context: APIContext) {
     {
       title: 'RSS feed',
       href: '/rss.xml',
-      note: 'Full blog feed generated from the posts collection.',
+      note: 'Full-content feed of the 30 most recent blog posts.',
     },
     {
       title: 'Sitemap index',
@@ -100,7 +100,7 @@ export async function GET(context: APIContext) {
     '',
     '> Personal site and blog by Otávio Miranda, a Brazilian software developer and technology educator. The primary language is Brazilian Portuguese.',
     '',
-    'This file is a concise guide for LLMs and agents. It is generated during the Astro static build from site metadata, course data, and the posts content collection. Use the sitemap for exhaustive crawling and the RSS feed for the full blog feed.',
+    'This file is a concise guide for LLMs and agents. It is generated during the Astro static build from site metadata, course data, and the posts content collection. Use the sitemap for exhaustive crawling and the RSS feed for recent posts.',
     '',
     'Content themes include Python, JavaScript, TypeScript, web development, Linux, DevOps, AI tooling, security notes, and software engineering education.',
     '',

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -4,6 +4,8 @@ import { getCollection } from 'astro:content';
 import { Marked } from 'marked';
 import { getEntryHref } from '../utils/post-path';
 
+const RSS_POST_LIMIT = 30;
+
 const marked = new Marked({
   renderer: {
     html(token) {
@@ -19,16 +21,16 @@ function isHtmlComment(value: string): boolean {
 
 export async function GET(context: APIContext) {
   const posts = await getCollection('posts');
-  const sortedPosts = posts.sort(
-    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
-  );
+  const recentPosts = posts
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+    .slice(0, RSS_POST_LIMIT);
 
   return rss({
     title: 'Otávio Miranda',
     description: 'Blog do Otávio Miranda — Tech, Linux e DevOps',
     site: context.site!.href,
     items: await Promise.all(
-      sortedPosts.map(async post => ({
+      recentPosts.map(async post => ({
         title: post.data.title,
         description: post.data.description,
         pubDate: post.data.date,


### PR DESCRIPTION
## What changed
- limits the full-content RSS feed to the 30 most recent posts
- updates `llms.txt` discovery copy to describe the bounded feed accurately
- reduces the generated feed from 3.5 MB (196 entries) to 469 KB (30 entries)

## Related issue
closes #211

## How to test
- [x] Build the site and verify `dist/rss.xml` contains 30 `<item>` elements
- [x] Verify recent RSS entries still contain full article content
- [x] `npm run build` passes

## Checks
- `npm run build`: passes
- `npm run lint`: Astro diagnostics pass; repository-wide Prettier check remains red because of existing missing glob targets and 160 pre-existing formatting warnings (neither changed file is listed)