### PR TITLE
fix(search): support 16 KiB Linux pages and validate build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@ npm run dev        # dev server
 npm run build      # production build
 npm run preview    # preview the build locally
 npm run lint       # Astro check + Prettier
+npm run test:search # search-output guard fixtures
 ```
+
+The production build removes only the previous `dist/pagefind` output before
+building, then checks the generated browser bundle, entry manifest, language
+metadata/WASM, and nonempty index/fragments. A successful Astro exit alone does
+not establish a working search build. Missing search output fails the build; it
+must not be replaced with placeholder files or silently disabled.
+
+Pagefind and its browser component are pinned to `1.5.0`: the `1.5.2` Linux
+ARM64 binary aborts on 16 KiB kernel pages. Keep the wrapper, platform binaries,
+and UI aligned in the lockfile. Test both the Node API and real index generation
+on a 16 KiB host before lifting this compatibility pin.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/rss": "^4.0.19",
         "@astrojs/sitemap": "^3.7.3",
+        "@pagefind/component-ui": "1.5.0",
         "cheerio": "^1.2.0",
         "marked": "^17.0.3",
         "prettier-plugin-astro": "^0.14.1"
@@ -19,7 +20,8 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "astro": "^7.0.6",
-        "astro-pagefind": "^2.0.1",
+        "astro-pagefind": "2.0.1",
+        "pagefind": "1.5.0",
         "typescript": "^5.9.3"
       }
     },
@@ -1696,10 +1698,9 @@
       }
     },
     "node_modules/@pagefind/component-ui": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/component-ui/-/component-ui-1.5.2.tgz",
-      "integrity": "sha512-t8/aE0tan4JiKa6cyhhSt/5qrEVwAK/qlYBHFpnRoq+qaFFVrhmXFFMY+r6n4GJtVIFCN2A5nUpeLN68cYjEjw==",
-      "dev": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/component-ui/-/component-ui-1.5.0.tgz",
+      "integrity": "sha512-lOyk1+7x5Ds0TkAXXR0o6XYITtzmx9QjtrhiPNxI7zuwmO6tr0fqaxTengz3LtvvhHoXawW/h8BEHaTaQMTegQ==",
       "license": "MIT",
       "dependencies": {
         "adequate-little-templates": "^1.0.2",
@@ -1707,9 +1708,9 @@
       }
     },
     "node_modules/@pagefind/darwin-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
-      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.0.tgz",
+      "integrity": "sha512-OXQVlxALU9+Lz/LxkAa+RvaxY1cnRKUDCuwl9o8PY5Lg/znP573y4WIbVOOIz8Bv7uj7r00TGy7pD+NSLMJGBw==",
       "cpu": [
         "arm64"
       ],
@@ -1721,9 +1722,9 @@
       ]
     },
     "node_modules/@pagefind/darwin-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
-      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.0.tgz",
+      "integrity": "sha512-+LK1Xq5n/B0hHc08DW61SnfIlfLKyXZ1oKcbfZ1MimE7Rn0Q6R0VI/TlC04f/JDPm+67zAOwPGizzvefOi5vqQ==",
       "cpu": [
         "x64"
       ],
@@ -1735,9 +1736,9 @@
       ]
     },
     "node_modules/@pagefind/freebsd-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
-      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.0.tgz",
+      "integrity": "sha512-kicDfUF9gn/z06NimTwNlZXF8z3pLsN3BIPPt6N8unuh0n55fr64tVs2p3a5RKYmQkJGjPfOE/C9GI5YTEpURg==",
       "cpu": [
         "x64"
       ],
@@ -1749,9 +1750,9 @@
       ]
     },
     "node_modules/@pagefind/linux-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
-      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.0.tgz",
+      "integrity": "sha512-e5rDB3wPm89bcSLiatKBDTrVTbsMQrrtkXRaAoUJYU0C1suXVvEzZfjmMvrUDvYhZBx/Ls8hGuGxlqSJBz3gDg==",
       "cpu": [
         "arm64"
       ],
@@ -1763,9 +1764,9 @@
       ]
     },
     "node_modules/@pagefind/linux-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
-      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.0.tgz",
+      "integrity": "sha512-vh52DcBiF/mRMmq+Rwt3M3RgEWgl00jFk/M5NWhLEHJFq4+papQXwbyKbi7cNlxaeYrKx6wOfW3fm9cftfc/Kg==",
       "cpu": [
         "x64"
       ],
@@ -1777,9 +1778,9 @@
       ]
     },
     "node_modules/@pagefind/windows-arm64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
-      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.0.tgz",
+      "integrity": "sha512-kg+szZwffZdyWn6SL6RHjAYjhSvJ2bT4qkv3KepGsbmD9fuSHUSC+2kydDneDVUA9qEDRf9uSFoEAsXsp1/JKA==",
       "cpu": [
         "arm64"
       ],
@@ -1791,9 +1792,9 @@
       ]
     },
     "node_modules/@pagefind/windows-x64": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
-      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.0.tgz",
+      "integrity": "sha512-8eOCmB8lnpyvwz+HrcTXLuBxhj7UseAFh6KGEXRe8UCcAfVQih+qPy/4akJRezViI+ONijz9oi7HpMkw9rdtBg==",
       "cpu": [
         "x64"
       ],
@@ -2801,7 +2802,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/adequate-little-templates/-/adequate-little-templates-1.0.2.tgz",
       "integrity": "sha512-d0tFFG538l3Y4CElRKtticzrMr/OGohs32/nf3Ewn8rbTMBYwkVNe8mPdXWrDnMlz+ZVUFQjsTmsBD5zCtU4wg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -3067,7 +3067,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
       "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
@@ -4195,7 +4194,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4206,7 +4204,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
       "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
@@ -4221,7 +4218,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
       "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5697,22 +5693,22 @@
       "license": "MIT"
     },
     "node_modules/pagefind": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
-      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.0.tgz",
+      "integrity": "sha512-7vQ2xh0ZmjPjsuWONR68nqzb+QNfpPh7pdT6n6YDAthWAQiUkSACVegSswY5zPNONGYFWebFVgdnS5/m/Qqn+w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "pagefind": "lib/runner/bin.cjs"
       },
       "optionalDependencies": {
-        "@pagefind/darwin-arm64": "1.5.2",
-        "@pagefind/darwin-x64": "1.5.2",
-        "@pagefind/freebsd-x64": "1.5.2",
-        "@pagefind/linux-arm64": "1.5.2",
-        "@pagefind/linux-x64": "1.5.2",
-        "@pagefind/windows-arm64": "1.5.2",
-        "@pagefind/windows-x64": "1.5.2"
+        "@pagefind/darwin-arm64": "1.5.0",
+        "@pagefind/darwin-x64": "1.5.0",
+        "@pagefind/freebsd-x64": "1.5.0",
+        "@pagefind/linux-arm64": "1.5.0",
+        "@pagefind/linux-x64": "1.5.0",
+        "@pagefind/windows-arm64": "1.5.0",
+        "@pagefind/windows-x64": "1.5.0"
       }
     },
     "node_modules/parse-latin": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "node scripts/check_css_tokens.mjs && astro check && astro build && node scripts/check_social_meta.mjs",
+    "build": "node scripts/check_search_index.mjs --prepare && node scripts/check_css_tokens.mjs && astro check && astro build && node scripts/check_search_index.mjs && node scripts/check_social_meta.mjs",
+    "test:search": "node --test scripts/test_search_index.mjs",
     "lint": "astro check && prettier --check --config .prettierrc.json \"AGENTS.md\" \"PLAN.md\" \"README.md\" \"astro.config.mjs\" \"package.json\" \".github/**/*.{yml,yaml}\" \"public/**/*.{css,js}\" \"scripts/**/*.{js,mjs,ts}\" \"src/**/*.{astro,ts,js,mjs,md,mdx,html,css,json}\"",
     "lint:fix": "prettier --write --ignore-path NUL --config .prettierrc.json \"AGENTS.md\" \"PLAN.md\" \"README.md\" \"astro.config.mjs\" \"package.json\" \".github/**/*.{yml,yaml}\" \"public/**/*.{css,js}\" \"scripts/**/*.{js,mjs,ts}\" \"src/**/*.{astro,ts,js,mjs,md,mdx,html,css,json}\"",
     "preview": "astro preview",
@@ -26,10 +27,16 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "astro": "^7.0.6",
-    "astro-pagefind": "^2.0.1",
+    "astro-pagefind": "2.0.1",
+    "pagefind": "1.5.0",
     "typescript": "^5.9.3"
   },
+  "overrides": {
+    "pagefind": "1.5.0",
+    "@pagefind/component-ui": "1.5.0"
+  },
   "dependencies": {
+    "@pagefind/component-ui": "1.5.0",
     "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.3",

--- a/scripts/check_search_index.mjs
+++ b/scripts/check_search_index.mjs
@@ -1,0 +1,76 @@
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+const directory = join(process.cwd(), 'dist', 'pagefind');
+try {
+  if (
+    process.argv.length > 3 ||
+    (process.argv[2] !== undefined && process.argv[2] !== '--prepare')
+  ) {
+    throw new Error('Usage: node scripts/check_search_index.mjs [--prepare]');
+  }
+  for (const path of [join(process.cwd(), 'dist'), directory]) {
+    if (lstatSync(path, { throwIfNoEntry: false })?.isSymbolicLink()) {
+      throw new Error(`Refusing symlink output: ${path}`);
+    }
+  }
+  if (process.argv[2] === '--prepare') {
+    rmSync(directory, { recursive: true, force: true });
+    process.exit(0);
+  }
+  for (const name of ['pagefind.js', 'pagefind-entry.json']) {
+    const file = statSync(join(directory, name));
+    if (!file.isFile() || file.size === 0)
+      throw new Error(`Missing or empty ${name}`);
+  }
+  const entry = JSON.parse(
+    readFileSync(join(directory, 'pagefind-entry.json'), 'utf8'),
+  );
+  if (
+    !Object.values(entry.languages ?? {}).some(
+      language => language.page_count > 0,
+    )
+  ) {
+    throw new Error('No indexed pages');
+  }
+  for (const language of Object.values(entry.languages)) {
+    if (
+      !/^[\w-]+$/.test(language.hash) ||
+      (language.wasm != null && !/^[\w-]+$/.test(language.wasm))
+    ) {
+      throw new Error('Invalid language asset identifier');
+    }
+    for (const name of [
+      `pagefind.${language.hash}.pf_meta`,
+      `pagefind.${language.wasm ?? 'unknown'}.wasm`,
+    ]) {
+      const file = statSync(join(directory, name));
+      if (!file.isFile() || file.size === 0)
+        throw new Error(`Missing or empty ${name}`);
+    }
+  }
+  for (const [folder, suffix] of [
+    ['index', '.pf_index'],
+    ['fragment', '.pf_fragment'],
+  ]) {
+    const files = readdirSync(join(directory, folder)).filter(name =>
+      name.endsWith(suffix),
+    );
+    if (files.length === 0) throw new Error(`No ${folder} chunks`);
+    for (const name of files) {
+      const file = statSync(join(directory, folder, name));
+      if (!file.isFile() || file.size === 0)
+        throw new Error(`Missing or empty ${name}`);
+    }
+  }
+  console.log('Search index validated.');
+} catch (error) {
+  console.error(`Search index validation failed: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/check_search_index.mjs
+++ b/scripts/check_search_index.mjs
@@ -48,7 +48,7 @@ try {
     }
     for (const name of [
       `pagefind.${language.hash}.pf_meta`,
-      `pagefind.${language.wasm ?? 'unknown'}.wasm`,
+      `wasm.${language.wasm ?? 'unknown'}.pagefind`,
     ]) {
       const file = statSync(join(directory, name));
       if (!file.isFile() || file.size === 0)

--- a/scripts/test_search_index.mjs
+++ b/scripts/test_search_index.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const script = fileURLToPath(
+  new URL('./check_search_index.mjs', import.meta.url),
+);
+
+function fixture() {
+  const cwd = mkdtempSync(join(tmpdir(), 'search-index-test-'));
+  const output = join(cwd, 'dist', 'pagefind');
+  mkdirSync(output, { recursive: true });
+  writeFileSync(join(output, 'pagefind.js'), '// fixture browser bundle');
+  writeFileSync(
+    join(output, 'pagefind-entry.json'),
+    JSON.stringify({
+      version: '1.5.0',
+      languages: { pt: { hash: 'pt_test', wasm: 'pt', page_count: 1 } },
+    }),
+  );
+  return { cwd, output };
+}
+
+test('build rejects an entry manifest whose language data is missing', () => {
+  const { cwd } = fixture();
+  try {
+    const result = spawnSync(process.execPath, [script], {
+      cwd,
+      encoding: 'utf8',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Search index validation failed/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('build rejects language metadata without search index chunks', () => {
+  const { cwd, output } = fixture();
+  writeFileSync(join(output, 'pagefind.pt_test.pf_meta'), 'metadata');
+  writeFileSync(join(output, 'pagefind.pt.wasm'), 'wasm');
+  try {
+    const result = spawnSync(process.execPath, [script], {
+      cwd,
+      encoding: 'utf8',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Search index validation failed/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('build accepts a complete nonempty search output package', () => {
+  const { cwd, output } = fixture();
+  for (const name of [
+    'pagefind.pt_test.pf_meta',
+    'pagefind.pt.wasm',
+    'index/pt_test.pf_index',
+    'fragment/pt_test.pf_fragment',
+  ]) {
+    mkdirSync(join(output, name, '..'), { recursive: true });
+    writeFileSync(join(output, name), 'fixture bytes');
+  }
+  try {
+    const result = spawnSync(process.execPath, [script], {
+      cwd,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Search index validated/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('build preparation removes only the previous search output', () => {
+  const { cwd, output } = fixture();
+  const page = join(cwd, 'dist', 'index.html');
+  writeFileSync(page, '<h1>Preserve other output</h1>');
+  try {
+    const result = spawnSync(process.execPath, [script, '--prepare'], {
+      cwd,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(output), false);
+    assert.equal(existsSync(page), true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('build rejects missing search output with an actionable diagnostic', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'search-index-test-'));
+  try {
+    const result = spawnSync(process.execPath, [script], {
+      cwd,
+      encoding: 'utf8',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Search index validation failed/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/scripts/test_search_index.mjs
+++ b/scripts/test_search_index.mjs
@@ -48,7 +48,7 @@ test('build rejects an entry manifest whose language data is missing', () => {
 test('build rejects language metadata without search index chunks', () => {
   const { cwd, output } = fixture();
   writeFileSync(join(output, 'pagefind.pt_test.pf_meta'), 'metadata');
-  writeFileSync(join(output, 'pagefind.pt.wasm'), 'wasm');
+  writeFileSync(join(output, 'wasm.pt.pagefind'), 'wasm');
   try {
     const result = spawnSync(process.execPath, [script], {
       cwd,
@@ -65,7 +65,7 @@ test('build accepts a complete nonempty search output package', () => {
   const { cwd, output } = fixture();
   for (const name of [
     'pagefind.pt_test.pf_meta',
-    'pagefind.pt.wasm',
+    'wasm.pt.pagefind',
     'index/pt_test.pf_index',
     'fragment/pt_test.pf_fragment',
   ]) {


### PR DESCRIPTION
## What changed
- Pin Pagefind/native packages and component UI to the verified compatible 1.5.0 release; keep astro-pagefind at 2.0.1.
- Declare directly imported UI and the Pagefind CLI explicitly instead of relying on transitive hoisting.
- Remove previous generated search output before a production build and reject missing bundles, empty manifests/language data, or absent index/fragments afterward.
- Document the compatibility pin and add five CLI regression fixtures.

## Related issue
Closes #217

## How to test
- [x] Five search-output guard fixtures pass (`npm run test:search`).
- [x] Pagefind 1.5.0 CLI and Node API index a real Portuguese fixture on a 16 KiB Fedora host and the existing Pi container image.
- [x] Lockfile changes are restricted to Pagefind and the direct UI dependency's production classification.
- [ ] Full host and container `npm ci`/`npm run build` with the prepared edition: in progress before merge.

No editorial content, credentials, runtime state, Docker image, or production schedule is changed by this PR. The stopped edition will be recovered separately after the real build gates pass.
