### PR TITLE
fix(deploy): allow fifteen minutes for Pages publication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -31,3 +32,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          timeout: 900000


### PR DESCRIPTION
Closes #219. Set the Pages action timeout to 900000 milliseconds (15 minutes), with a 20-minute outer job ceiling for cancellation overhead and runner-cost protection. Build and TTS limits unchanged. Exact YAML diff/units checked; the authorized real deployment is the integration test. No post/audio bytes changed.