### PR TITLE
fix(deploy): respect the Pages action timeout ceiling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,4 +33,4 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         with:
-          timeout: 900000
+          timeout: 600000 # Maximum supported by actions/deploy-pages.


### PR DESCRIPTION
Closes #221. Restore the actual supported 600000ms maximum after the live Action warned and clamped 900000ms. Deployment completed successfully with that enforced limit. Only one YAML scalar/comment changed; whitespace and complete staged diff checked. No audio, content, build or new workflow execution.